### PR TITLE
Add error handling for watchOS 2 logic

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -523,6 +523,9 @@ static BOOL AFSecKeyIsEqualToKey(SecKeyRef key1, SecKeyRef key2) {
          dataTaskWithRequest:self.request
          completionHandler:^(NSData *data, NSURLResponse *response, NSError *error)
          {
+             if (error) {
+                 self.error = error;
+             }
              self.response = response;
              self.responseData = data;
              [self.outputStream close];


### PR DESCRIPTION
In the branching logic for watchOS 2, we must set the value of `self.error` if there is in fact an error, in analogy with the behavior of the NSURLConnectionDelegate method `connection:didFailWithError:`.
